### PR TITLE
fix null pointer dereference

### DIFF
--- a/src/videotexturebackend/videotexturebackend.cpp
+++ b/src/videotexturebackend/videotexturebackend.cpp
@@ -611,6 +611,10 @@ bool NemoVideoTextureBackend::init(QMediaService *service)
         return false;
     }
 
+    if (!service) {
+        return false;
+    }
+
     QMediaControl *control = service->requestControl(QGStreamerVideoSinkControl_iid);
     if (control) {
         m_control = qobject_cast<QGStreamerElementControl *>(control);


### PR DESCRIPTION
QML VideoOutput documentation says that "...you can provide a QObject
based class with a writable `videoSurface` property..." (as a source).
QDeclarativeVideoOutput then tries to initialize video backend with
nullptr service. It leads to null pointer dereference and crash
in NemoVideoTextureBackend::init.

Crash stacktrace:

	#0  0x0000007280487ed0 in NemoVideoBackend::NemoVideoTextureBackend::init (this=0x60b4fb10d0, service=0x0) at videotexturebackend.cpp:614
	#1  0x0000007284a26ea4 in QDeclarativeVideoOutput::createBackend (this=this@entry=0x60b4f84c10, service=service@entry=0x0) at /usr/include/qt5/QtCore/qscopedpointer.h:127
	#2  0x0000007284a27c14 in QDeclarativeVideoOutput::setSource (this=0x60b4f84c10, source=0x60b527f520) at qdeclarativevideooutput.cpp:206
	#3  0x0000007284a2f078 in QDeclarativeVideoOutput::qt_metacall (this=0x60b4f84c10, _c=QMetaObject::WriteProperty, _id=0, _a=0x7ff48f04c0) at .moc/moc_qdeclarativevideooutput_p.cpp:343
	#4  0x000000728e71bd74 in QQmlPropertyPrivate::write (object=object@entry=0x60b4f84c10, property=..., value=..., context=0x60b4f55e20, flags=flags@entry=...) at qml/qqmlproperty.cpp:1252